### PR TITLE
Fix issue #14: separate last 2 tags in unify.String()

### DIFF
--- a/yago/json2yara.go
+++ b/yago/json2yara.go
@@ -62,11 +62,11 @@ func (u *unify) String() string {
 
 		r += fmt.Sprintf("rule %s", rule.Name)
 		if len(rule.Tags) > 0 {
-			r += fmt.Sprintf(" :")
-			for i := 0; i < len(rule.Tags)-1; i++ {
-				r += fmt.Sprintf(" %s", rule.Tags[i])
+			r += " :"
+			for _, tag := range rule.Tags {
+				r += fmt.Sprintf(" %s", tag)
 			}
-			r += fmt.Sprintf("%s {\n", rule.Tags[len(rule.Tags)-1])
+			r += " {\n"
 		} else {
 			r += fmt.Sprintf(" {\n")
 		}


### PR DESCRIPTION
I think this was the intended behavior